### PR TITLE
Move `claims` to JPT from JWP

### DIFF
--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -97,9 +97,14 @@ To generate a variety of efficient ZKPs of knowledge, range, membership, or othe
 
 It is RECOMMENDED that the claim names used with JPTs come from those in the IANA JSON Web Token Claims Registry [@IANA.JWT.Claims] established by [@!RFC7519], when those fit the application's needs.
 
-# Claims
+# Claims Header Parameter {#claimsDef}
 
-A JSON Proof Token assigns each playload a claim name. Payloads MUST each have a negotiated and understood claim name within the application context. The simplest solution to establish payload claim names is as an ordered array that aligns with the included payloads.  This claims array can be conveniently included in the Issuer Protected Header using the `claims` key.
+A JSON Proof Token assigns each playload a claim name. Payloads MUST each have a negotiated and understood claim name within the application context. The simplest solution to establish payload claim names is as an ordered array that aligns with the included payloads.  This claims array can be conveniently included in the Claims header parameter.
+
+The `claims` Header Parameter is an array listing the Claim Names
+corresponding to the JWP payloads, in the same order as the payloads.
+Each array value is a Claim Name, as defined in [@!RFC7519].
+Use of this Header Parameter is OPTIONAL.
 
 All payloads are claim values and MUST be the base64url encoding of the UTF-8 representation of a JSON value.
 That said, predicate proofs derived from payload values are not represented as claims;
@@ -114,6 +119,7 @@ In this example, the "iat" and "exp" would be JSON-formatted numbers, "family_na
 # Claims ID ("cid") JWP Header Parameter {#cidDef}
 
 A Claims ID ("cid") value can be used as an identifier for a set of claim names without explicitly listing them.
+
 The structure of the `cid` value is unspecified.
 Its value MUST be a case-sensitive string.
 Use of this JWP Header Parameter is OPTIONAL.
@@ -176,14 +182,23 @@ established by [@!I-D.ietf-jose-json-web-proof].
 
 ### Registry Contents {#HdrContents}
 
-#### Claims ID Header Parameter
+#### "claims" (Claims) Header Parameter
 
-* Header Parameter Name: `cid`
-* Header Parameter Description: Claims ID
-* Header Parameter Usage Location(s): Issued, Presented
+* Header Parameter Name: Claims
+* Header Parameter JSON Label: `claims`
+* Header Parameter CBOR Label: 10
+* Header Parameter Usage Location(s): Issued
+* Change Controller: IETF
+* Specification Document(s): (#claimsDef) of this specification
+
+#### "cid" (Claims ID) Header Parameter
+
+* Header Parameter Name: Claims ID
+* Header Parameter JSON Label: `cid`
+* Header Parameter CBOR Label: 11
+* Header Parameter Usage Location(s): Issued
 * Change Controller: IETF
 * Specification Document(s): (#cidDef) of this specification
-
 
 {backmatter}
 
@@ -212,6 +227,8 @@ for his valuable contributions to this specification.
  -latest
 
   * Changing primary editor
+  * Move `claims` definition from JWP, to live beside `cid`
+  * Update `cid` registry entry to assign CBOR label
 
  -06
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -398,13 +398,6 @@ registered in the IANA "JSON Web Token Claims" registry (#IANA.JWT.Claims).
 
 Use of this Header Parameter is OPTIONAL.
 
-### "claims" (Claims) Header Parameter {#claimsDef}
-
-The `claims` Header Parameter is an array listing the Claim Names
-corresponding to the JWP payloads, in the same order as the payloads.
-Each array value is a Claim Name, as defined in [@!RFC7519].
-Use of this Header Parameter is OPTIONAL.
-
 ## Public Header Parameter Names {#PublicHeaderParameterName}
 
 Additional Header Parameter names can be defined by those
@@ -815,20 +808,11 @@ This section registers the Header Parameters defined in
 * Change Controller: IETF
 * Specification Document(s): (#nonceDef) of this specification
 
-#### Claims Header Parameter
-
-* Header Parameter Name: Claims
-* Header Parameter JSON Label: `claims`
-* Header Parameter CBOR Label: 8
-* Header Parameter Usage Location(s): Issued
-* Change Controller: IETF
-* Specification Document(s): (#claimsDef) of this specification
-
 #### Proof Key Header Parameter
 
 * Header Parameter Name: Proof Key
 * Header Parameter JSON Label: `proof_key`
-* Header Parameter CBOR Label: 9
+* Header Parameter CBOR Label: 8
 * Header Parameter Usage Location(s): Issued
 * Change Controller: IETF
 * Specification Document(s): (#proof_keyDef) of this specification
@@ -837,7 +821,7 @@ This section registers the Header Parameters defined in
 
 * Header Parameter Name: Presentation Key
 * Header Parameter JSON Label: `presentation_key`
-* Header Parameter CBOR Label: 10
+* Header Parameter CBOR Label: 9
 * Header Parameter Usage Location(s): Issued
 * Change Controller: IETF
 * Specification Document(s): (#presentation_keyDef) of this specification
@@ -1067,6 +1051,8 @@ for his valuable contributions to this specification.
   * Clarified that `proof_key` and `presentation_key` are required
     by particular algorithms and are not more generally required for
     issued and presented JWPs.
+  * Move `claims` to JPT to live beside `cid`, and renumber CBOR
+    labels so that they may be adjacent
 
  -06
 


### PR DESCRIPTION
Also updates `cid` to the new registry format, and renumbers the CBOR labels (before first publication) so `claims` and `cid` are adjacent.