### PR TITLE
SU-ES256 issuer protected header no longer includes private keys

### DIFF
--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -855,9 +855,10 @@ The BBS examples were generated using the library at https://github.com/mattrglo
 
   [[ To be removed from the final specification ]]
 
- -08
+ -latest
 
   * Made some additional references normative.
+  * Corrected SU-ES256 issuer protected header including private keys
 
  -07
 

--- a/fixtures/su-es256-fixtures.mjs
+++ b/fixtures/su-es256-fixtures.mjs
@@ -34,8 +34,12 @@ const ephemeralPrivateKey = crypto.createPrivateKey({
 // storage as we build up
 const sigs = [];
 
-issuerProtectedHeaderJSON.proof_key = ephemeralPrivateKeyJSON;
-issuerProtectedHeaderJSON.presentation_key = holderPrivateKeyJSON;
+issuerProtectedHeaderJSON.proof_key = structuredClone(ephemeralPrivateKeyJSON);
+delete issuerProtectedHeaderJSON.proof_key.d;
+
+issuerProtectedHeaderJSON.presentation_key = structuredClone(holderPrivateKeyJSON);
+delete issuerProtectedHeaderJSON.presentation_key.d;
+
 await fs.writeFile("build/su-es256-issuer-protected-header.json", JSON.stringify(issuerProtectedHeaderJSON, null, 2), {encoding: "UTF-8"});
 await fs.writeFile("build/su-es256-issuer-protected-header.json.wrapped", lineWrap(JSON.stringify(issuerProtectedHeaderJSON, null, 2)), {encoding: "UTF-8"});
 


### PR DESCRIPTION
Correction to generation code for example