### PR TITLE
Removing json serialization

### DIFF
--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -245,7 +245,7 @@ The operation also takes a vector of indexes into `messages`, describing which p
 
 The output of this operation is the presentation proof, as a single octet string.
 
-Presentation serialization leverages the two protected headers and presentation proof, along with the disclosed payloads. Non-disclosed payloads are represented with the absent value of `null` in JSON serialization and a zero-length string in compact serialization.
+Presentation serialization leverages the two protected headers and presentation proof, along with the disclosed payloads. Non-disclosed payloads are represented with the absent value of `null` in CBOR serialization and a zero-length string in compact serialization.
 
 ### Presentation Verification
 
@@ -679,15 +679,10 @@ The final proof value from the Issuer is an array with the octets of the header 
 <{{./fixtures/template/jpt-issuer-payloads.json}}
 Figure: Issuer payloads (JSON, as array)
 
-The resulting JSON serialized JPT using the above examples is:
-
-<{{./fixtures/build/su-es256-issuer.json.jwp.wrapped}}
-Figure: Issued JWP (SU-ES256, JSON Serialization)
-
 The compact serialization of the same JPT is:
 
 <{{./fixtures/build/su-es256-issuer.compact.jwp.wrapped}}
-Figure: Issued JWP (SU-ES256, Compact Serialization)
+Figure: Issued JWP (SU-ES256, JSON, Compact Serialization)
 
 To present this JPT, we first use the following presentation header with a nonce (provided by the Verifier):
 
@@ -695,26 +690,23 @@ To present this JPT, we first use the following presentation header with a nonce
 Figure: Presentation Header (SU-ES256, JSON)
 
 <{{./fixtures/build/su-es256-holder-protected-header.b64.wrapped}}
-Figure: Presentation Header (SU-ES256, JSON, encoded)
+Figure: Presentation Header (SU-ES256, JSON, BASE64URL-Encoded)
 
 When signed with the holder's presentation key, the resulting signature are:
 
 <{{./fixtures/build/su-es256-holder-pop.b64.wrapped}}>
-Figure: Holder Proof-of-Possession (SU-ES256 for JSON serializations)
+Figure: Holder Proof-of-Possession (SU-ES256, JSON)
 
-Then by applying selective disclosure of only the given name and age claims (family name and email hidden), we get the following presented JPT:
-
-<{{./fixtures/build/su-es256-presentation.json.jwp.wrapped}}>
-Figure: Presentation (SU-ES256, JSON Serialization)
-
-And also in compact serialization:
+Then by applying selective disclosure of only the given name and age
+claims (family name and email hidden), we get the following presented
+JPT in compact serialization:
 
 <{{./fixtures/build/su-es256-presentation.compact.jwp.wrapped}}>
-Figure: Presentation (SU-ES256, Compact Serialization)
+Figure: Presentation (SU-ES256, JSON, Compact Serialization)
 
 ## Example CBOR-Serialized Single-Use CPT
 
-This example is meant to mirror the prior JSON serialization, using
+This example is meant to mirror the prior compact serialization, using
 [RFC8392] (CWT) and claims from [@I-D.maldant-spice-oidc-cwt#02],
 illustrated using [@I-D.ietf-cbor-edn-literals] (EDN).
 
@@ -762,26 +754,20 @@ For the following protected header and array of payloads:
 <{{./fixtures/template/jpt-issuer-protected-header.json}}
 Figure: Example issuer protected header
 
-These components are signed using the private issuer key previously given, which is then representable in the following serializations:
-
-<{{./fixtures/build/bbs-issuer.json.jwp.wrapped}}
-Figure: Issued JWP (JSON serialization)
+These components are signed using the private issuer key previously given, which is then representable in the following serialization:
 
 <{{./fixtures/build/bbs-issuer.compact.jwp.wrapped}}
-Figure: Issued JWP (compact serialization)
+Figure: Issued JWP (BBS, JSON, Compact Serialization)
 
 For a presentation with the following presentation header:
 
 <{{./fixtures/template/bbs-holder-presentation-header.json}}
 Figure: Holder Presentation Header
 
-The holder decides to share all information other than the email address, and generates a proof. That proof is represented in the following serializations:
-
-<{{./fixtures/build/bbs-holder.json.jwp.wrapped}}
-Figure: Presentation JWP (JSON serialization)
+The holder decides to share all information other than the email address, and generates a proof. That proof is represented in the following serialization:
 
 <{{./fixtures/build/bbs-holder.compact.jwp.wrapped}}
-Figure: Presentation JWP (compact serialization)
+Figure: Presentation JWP (BBS, JSON, Compact serialization)
 
 ## Example MAC JWP
 
@@ -813,34 +799,29 @@ Figure: Example issuer payloads (as members of a JSON array)
 The first MAC is generated using the key `issuer_header` and a value of the issuer protected header as a UTF-8 encoded octet string. This results in the following MAC:
 
 <{{./fixtures/build/mac-h256-issuer-protected-header-mac.txt}}
-Figure: Issuer MAC of protected header (base64url-encoded)
+Figure: Issuer MAC of protected header (BASE64URL-Encoded)
 
 The issuer generates an array of derived keys with one for each payload by using the shared secret as the key, and the index of the payload (as `payload_{n}` in UTF-8 encoded octets) as the input in a HMAC operation. This results in the following set of derived keys:
 
 <{{./fixtures/build/mac-h256-issuer-derived-payload-keys.json}}
-Figure: Derived payload keys (base64url-encoded)
+Figure: Derived payload keys (BASE64URL-Encoded)
 
 A MAC is generated for each payload using the corresponding derived payload key. This results in the following set of MAC values:
 
 <{{./fixtures/build/mac-h256-payload-macs.json}}
-Figure: Payload MAC values (base64url-encoded)
+Figure: Payload MAC values (BASE64URL-Encoded)
 
 The issuer protected header MAC and the payload MAC octet strings are concatenated into a single value known as the combined MAC representation. This representation is signed with the issuer's private key.
 
 The proof consists of two octet string values: the signature over the combined MAC representation, and the shared secret.
 
 <{{./fixtures/build/mac-h256-issued-proof.json.wrapped}}
-Figure: Issued Proof (base64url-encoded)
+Figure: Issued Proof (BASE64URL-Encoded)
 
-The final issued JWP in JSON serialization is:
-
-<{{./fixtures/build/mac-h256-issuer.json.jwp.wrapped}}
-Figure: Issued JWP (in JSON serialization)
-
-The same JWP in compact serialization:
+The final issued JWP in compact serialization is:
 
 <{{./fixtures/build/mac-h256-issuer.compact.jwp.wrapped}}
-Figure: Issued JWP (in compact serialization)
+Figure: Issued JWP (MAC-H256, JSON, Compact Serialization)
 
 Next, we show the presentation of the JWP with selective disclosure.
 
@@ -858,17 +839,12 @@ For the disclosed payloads, the holder will provide the corresponding derived ke
 The final presented proof value is an array of octet strings. The contents are presentation header signature, followed by the issuer signature, then the value disclosed by the holder for each payload. This results in the following proof:
 
 <{{./fixtures/build/mac-h256-presentation-proof.json.wrapped}}
-Figure: Presentation proof (base64url-encoded)
+Figure: Presentation proof (BASE64URL-Encoded)
 
-The final presented JWP in JSON serialization is:
-
-<{{./fixtures/build/mac-h256-presentation.json.jwp.wrapped}}
-Figure: Presented JWP (in JSON serialization)
-
-The same JWP in compact serialization:
+The final presented JWP in compact serialization is:
 
 <{{./fixtures/build/mac-h256-presentation.compact.jwp.wrapped}}
-Figure: Presented JWP (in compact serialization)
+Figure: Presented JWP (MAC-H256, JSON, Compact Serialization)
 
 # Acknowledgements
 
@@ -886,6 +862,7 @@ The BBS examples were generated using the library at https://github.com/mattrglo
 
  -latest
 
+  * Remove JSON serialization
   * Added CBOR (CPT) example to the appendix using SU-ES256
 
  -08

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -799,7 +799,7 @@ Figure: Example issuer payloads (as members of a JSON array)
 The first MAC is generated using the key `issuer_header` and a value of the issuer protected header as a UTF-8 encoded octet string. This results in the following MAC:
 
 <{{./fixtures/build/mac-h256-issuer-protected-header-mac.txt}}
-Figure: Issuer MAC of protected header (BASE64URL-Encoded)
+Figure: Issuer MAC of protected header (Base64url-Encoded)
 
 The issuer generates an array of derived keys with one for each payload by using the shared secret as the key, and the index of the payload (as `payload_{n}` in UTF-8 encoded octets) as the input in a HMAC operation. This results in the following set of derived keys:
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -809,7 +809,7 @@ Figure: Derived payload keys (Base64url-Encoded)
 A MAC is generated for each payload using the corresponding derived payload key. This results in the following set of MAC values:
 
 <{{./fixtures/build/mac-h256-payload-macs.json}}
-Figure: Payload MAC values (BASE64URL-Encoded)
+Figure: Payload MAC values (Base64url-Encoded)
 
 The issuer protected header MAC and the payload MAC octet strings are concatenated into a single value known as the combined MAC representation. This representation is signed with the issuer's private key.
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -839,7 +839,7 @@ For the disclosed payloads, the holder will provide the corresponding derived ke
 The final presented proof value is an array of octet strings. The contents are presentation header signature, followed by the issuer signature, then the value disclosed by the holder for each payload. This results in the following proof:
 
 <{{./fixtures/build/mac-h256-presentation-proof.json.wrapped}}
-Figure: Presentation proof (BASE64URL-Encoded)
+Figure: Presentation proof (Base64url-Encoded)
 
 The final presented JWP in compact serialization is:
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -690,7 +690,7 @@ To present this JPT, we first use the following presentation header with a nonce
 Figure: Presentation Header (SU-ES256, JSON)
 
 <{{./fixtures/build/su-es256-holder-protected-header.b64.wrapped}}
-Figure: Presentation Header (SU-ES256, JSON, BASE64URL-Encoded)
+Figure: Presentation Header (SU-ES256, JSON, Base64url-Encoded)
 
 When signed with the holder's presentation key, the resulting signature are:
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -804,7 +804,7 @@ Figure: Issuer MAC of protected header (Base64url-Encoded)
 The issuer generates an array of derived keys with one for each payload by using the shared secret as the key, and the index of the payload (as `payload_{n}` in UTF-8 encoded octets) as the input in a HMAC operation. This results in the following set of derived keys:
 
 <{{./fixtures/build/mac-h256-issuer-derived-payload-keys.json}}
-Figure: Derived payload keys (BASE64URL-Encoded)
+Figure: Derived payload keys (Base64url-Encoded)
 
 A MAC is generated for each payload using the corresponding derived payload key. This results in the following set of MAC values:
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -816,7 +816,7 @@ The issuer protected header MAC and the payload MAC octet strings are concatenat
 The proof consists of two octet string values: the signature over the combined MAC representation, and the shared secret.
 
 <{{./fixtures/build/mac-h256-issued-proof.json.wrapped}}
-Figure: Issued Proof (BASE64URL-Encoded)
+Figure: Issued Proof (Base64url-Encoded)
 
 The final issued JWP in compact serialization is:
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -276,8 +276,6 @@ be shortened to `example;part="1/2"`.
 
 The `typ` value `jwp` can be used by applications
 to indicate that this object is a JWP using the JWP Compact Serialization.
-The `typ` value `jwp+json` can be used by applications
-to indicate that this object is a JWP using the JWP JSON Serialization.
 Other type values can also be used by applications.
 
 It is RECOMMENDED that the `typ` Header Parameter be used for explicit typing,
@@ -503,9 +501,9 @@ The algorithm is responsible for representing selective disclosure of payloads i
 
 Each disclosed payload MUST be base64url encoded when preparing it to be serialized.  The headers and proof are also individually base64url encoded.
 
-Like JWS, JWP supports both a Compact Serialization and a JSON Serialization. These serializations both represent the same JSON-based Protected Header, payloads and proof, and are thus interchangeable without breaking the proof value.
+JWP supports a Compact Serialization inspired by JWS. This serialization represents one or more JSON-based Protected Headers, multiple payloads, and a single proof.
 
-A CBOR-based serialization is also defined, which uses the CBOR for describing Header Parameters. While this supports the same data model and algorithms, the difference in header representations does not allow interchangeability with the Compact Serialization and JSON Serializations.
+A CBOR-based serialization is also defined, which uses the CBOR for describing Header Parameters. While this supports the same data model and algorithms, the difference in header representations does not allow interchangeability with Compact Serialization.
 
 ## Compact Serialization {#CompactSerialization}
 
@@ -527,25 +525,6 @@ The presented form is created by concatenating the base64url-encoded presenter p
 
 <{{./fixtures/build/bbs-holder.compact.jwp.wrapped}}>
 Figure: Compact Serialization of Presentation
-
-## JSON Serialization {#JSONSerialization}
-
-The JSON Serialization is in the form of a JSON object, with property names representing the various components.
-
-The Protected Headers MUST be JSON-formatted for JSON Serialization. This includes both headers sets in presented form.
-
-The `issuer` key has a string value holding the BASE64URL-encoded issuer protected header. This key MUST be included.
-
-The `presentation` key has a string value holding the BASE64URL-encoded presentation protected header. It MUST be included for presented form, and MUST be omitted for issued form.
-
-The `payloads` key has an array value, representing the ordered sequence of payloads. If a payload has been omitted, it is represented by the JSON value `null`. A payload is otherwise reprented by the BASE64URL-encoded form of the payload octets. A zero-length payload does not have special encoding rules as needed by compact encoding, and is represented by the zero-length string output by BASE64URL. This key MUST be included unless the application is using detached payloads.
-
-The `proof` key has an array value, representing the array of octet strings produced by the chosen algorithm. These octets are BASE64URL encoded into a JSON array.
-
-This example JSON serialization shows the presentation form with both the issuer and presentation headers, and with the first and third payloads hidden.
-
-<{{./fixtures/build/bbs-holder.json.jwp.wrapped}}>
-Figure: JSON Serialization of Presentation
 
 ## CBOR Serialization
 
@@ -618,8 +597,6 @@ JWE Header Parameter `cty` (content type) values SHOULD be used:
 
 * `jwp` is used to indicate that the content of the JWE is a JWP
 using the JWP Compact Serialization.
-* `jwp+json` is used to indicate that the content of the JWE is the
-UTF-8 encoding of a JWP using the JWP JSON Serialization.
 * `jwp+cbor` is used to indicate that the plaintext of the COSE
 message is a JWP in CBOR Serialization.
 
@@ -643,8 +620,11 @@ Notes to be expanded:
 * Requirements for supporting algorithms, see JPA
 * Application interface for verification
 * Data minimization of the protected header
-* To prevent accidentally introducing linkability, when an issuer uses the same key with the same grouping of payload types, they SHOULD also use the same issuer protected header.  Each of these headers SHOULD have the same base64url-serialized value to avoid any non-deterministic JSON serialization.
-
+* To prevent accidentally introducing linkability, when an issuer uses
+  the same key with the same grouping of payload types, they SHOULD
+  also use the same issuer protected header. This header SHOULD be
+  represented by the same octets, avoiding distinguishing a JWP
+  due to non-deterministic serialization.
 
 # IANA Considerations
 
@@ -838,10 +818,6 @@ in the IANA "Media Types" registry [@IANA.MediaTypes]
 in the manner described in [@RFC6838],
 which can be used to indicate that the content is
 a JWP using the JWP Compact Serialization.
-This section also registers the `application/jwp+json`
-media type in the IANA "Media Types" registry,
-which can be used to indicate that the content is
-a JWP using the JWP JSON Serialization.
 
 #### The application/jwp Media Type
 * Type name: application
@@ -849,29 +825,6 @@ a JWP using the JWP JSON Serialization.
 * Required parameters: n/a
 * Optional parameters: n/a
 * Encoding considerations: 8bit; application/jwp values are encoded as a series of base64url-encoded values (some of which may be the empty string) separated by period ('.') and tilde ('~') characters
-* Security considerations: See (#SecurityConsiderations) of this specification
-* Interoperability considerations: n/a
-* Published specification: this specification
-* Applications that use this media type: TBD
-* Fragment identifier considerations: n/a
-* Additional information:
-  - Magic number(s): n/a
-  - File extension(s): n/a
-  - Macintosh file type code(s): n/a
-* Person & email address to contact for further information: Michael B. Jones, michael_b_jones@hotmail.com
-* Intended usage: COMMON
-* Restrictions on usage: none
-* Author: Michael B. Jones, michael_b_jones@hotmail.com
-* Change Controller: IETF
-* Provisional registration? No
-
-#### The application/jwp+json Media Type
-
-* Type name: application
-* Subtype name: jwp+json
-* Required parameters: n/a
-* Optional parameters: n/a
-* Encoding considerations: 8bit; application/jwp+json values are represented as a JSON Object; UTF-8 encoding SHOULD be employed for the JSON object.
 * Security considerations: See (#SecurityConsiderations) of this specification
 * Interoperability considerations: n/a
 * Published specification: this specification
@@ -1039,6 +992,9 @@ for his valuable contributions to this specification.
 # Document History
 
   [[ To be removed from the final specification ]]
+ -latest
+
+  * Remove JSON serialization
 
  -08
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -499,15 +499,13 @@ The algorithm is responsible for representing selective disclosure of payloads i
 
 # Serializations
 
-Each disclosed payload MUST be base64url encoded when preparing it to be serialized.  The headers and proof are also individually base64url encoded.
+JWP defines two serializations: Compact Serialization and CBOR Serialization. Both serializations represent one or more Protected Headers, multiple Payloads, and a single Proof value.
 
-JWP supports a Compact Serialization inspired by JWS. This serialization represents one or more JSON-based Protected Headers, multiple payloads, and a single proof.
-
-A CBOR-based serialization is also defined, which uses the CBOR for describing Header Parameters. While this supports the same data model and algorithms, the difference in header representations does not allow interchangeability with Compact Serialization.
+JWP Compact Serialiation provides a JSON-based, space-efficient encoding of a JWP in URL-safe characters. JWP CBOR Serialization provides a compact CBOR-based encoding for more constrained environments.
 
 ## Compact Serialization {#CompactSerialization}
 
-The compact serialiation provides a JSON-based, space-efficient encoding of a JWP in URL-safe characters. In addition to the alphabet of unpadded BASE64 URL-safe encoding, it uses the "." and "~" characters as separators.
+JWP Compact Serialiation provides a JSON-based encoding of a JWP, expressed in URL-safe characters. In addition to the alphabet of unpadded BASE64URL-safe encoding, Compact Serialization uses the "." and "~" characters as separators. This serialization is inspired by JWS.
 
 The Protected Header MUST be JSON-formatted for Compact Serialization. This includes both headers sets in presented form.
 
@@ -528,6 +526,8 @@ Figure: Compact Serialization of Presentation
 
 ## CBOR Serialization
 
+A CBOR-based serialization is also defined, which uses the CBOR for describing Header Parameters and does not use base64url encoding to ensure safety in text-based protocols. While this supports the same data model and algorithms, the difference in header representations does not allow interchangeability with Compact Serialization.
+
 The CBOR serialization provides a compact binary representation of a JWP.
 The serialization consists of two arrays, representing issued and presented forms.
 
@@ -540,7 +540,7 @@ presented form consists of a four-element array.
 If an individual payload has been omitted, it is represented by the
 CBOR value `nil`. Payloads MUST be included unless the application
 is using detached payloads, which is represented by setting the
-`payloads` value as `nil`.¶
+`payloads` value as `nil`.
 
 Two tags are defined for representing issued and presented JWPs.
 Applications MAY use their own tags to tag other specific types of JWPs.

--- a/fixtures/bbs-fixtures.mjs
+++ b/fixtures/bbs-fixtures.mjs
@@ -37,17 +37,6 @@ const compactSerialization = [
 await fs.writeFile("build/bbs-issuer.compact.jwp", compactSerialization, {encoding: "UTF-8"});
 await fs.writeFile("build/bbs-issuer.compact.jwp.wrapped", lineWrap(compactSerialization));
 
-// JSON Serialization
-const jsonSerialziation = {
-    issuer: encode(protectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: [ encode(signature) ]
-};
-
-let jsonSerializationStr = JSON.stringify(jsonSerialziation, null, 2);
-await fs.writeFile("build/bbs-issuer.json.jwp", jsonSerializationStr);
-await fs.writeFile("build/bbs-issuer.json.jwp.wrapped", lineWrap(jsonSerializationStr, 8));
-
 // Generate proof, selectively disclosing only name and age
 var proof = await pairing.bbs.bls12381_sha256.deriveProof({
     publicKey: keyPair.publicKey.compressed,
@@ -81,15 +70,3 @@ const compactHolderSerialization = [
 ].join(".");
 await fs.writeFile("build/bbs-holder.compact.jwp", compactHolderSerialization, {encoding: "UTF-8"});
 await fs.writeFile("build/bbs-holder.compact.jwp.wrapped", lineWrap(compactHolderSerialization, 0));
-
-// JSON Serialization
-const jsonHolderSerialization = {
-    presentation: encode(presentationHeader),
-    issuer: encode(protectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: [ encode(proof) ]
-};
-
-var jsonHolderSerializationStr = JSON.stringify(jsonHolderSerialization, null, 2);
-await fs.writeFile("build/bbs-holder.json.jwp", jsonHolderSerializationStr, {encoding: "UTF-8"});
-await fs.writeFile("build/bbs-holder.json.jwp.wrapped", lineWrap(jsonHolderSerializationStr, 8), {encoding: "UTF-8"});

--- a/fixtures/mac-h256-fixtures.mjs
+++ b/fixtures/mac-h256-fixtures.mjs
@@ -83,14 +83,6 @@ const issuedProof = [macsSignature, holderSharedSecret]
 
 await fs.writeFile("build/mac-h256-issued-proof.json.wrapped", lineWrap(JSON.stringify(issuedProof.map(encode), 0, 2)));
 
-// create issued JSON serialization
-const finalIssuedJSON = {
-    issuer: encode(finalIssuerProtectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: issuedProof.map(encode)
-}
-const issuerJSONOutput = JSON.stringify(finalIssuedJSON, 0, 2);
-
 // create issued compact serialization
 const serialized = [];
 serialized.push(encode(finalIssuerProtectedHeader));
@@ -98,7 +90,6 @@ serialized.push(payloads.map(compactPayloadEncode).join('~'));
 serialized.push(issuedProof.map(encode).join("~"));
 const issuerCompactOutput = serialized.join('.');
 
-await fs.writeFile("build/mac-h256-issuer.json.jwp.wrapped", lineWrap(issuerJSONOutput));
 await fs.writeFile("build/mac-h256-issuer.compact.jwp.wrapped", lineWrap(issuerCompactOutput));
 
 /// Create JWP Presentation
@@ -131,20 +122,8 @@ for (let i = 0 ; i < payloads.length; i++ ) {
     }
 }
 
-// await fs.writeFile("build/mac-h256-presentation-disclosures.json.wrapped",
-//     lineWrap(JSON.stringify(pres_final.slice(2).map(encode), 0, 2)));
-
 await fs.writeFile("build/mac-h256-presentation-proof.json.wrapped",
     lineWrap(JSON.stringify(pres_final.map(encode), 0, 2)));
-
-// create issued JSON serialization
-const finalPresentedJSON = {
-    presentation: encode(finalHolderProtectedHeader),
-    issuer: encode(finalIssuerProtectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: pres_final.map(encode)
-}
-const presentedJSONOutput = JSON.stringify(finalPresentedJSON, 0, 2);
 
 // create issued compact serialization
 const serialized2 = [];
@@ -154,7 +133,5 @@ serialized2.push(payloads.map(compactPayloadEncode).join('~'));
 serialized2.push(pres_final.map(encode).join('~'));
 const presentedCompactOutput = serialized2.join('.');
 
-await fs.writeFile("build/mac-h256-presentation.json.jwp.wrapped",
-    lineWrap(presentedJSONOutput));
 await fs.writeFile("build/mac-h256-presentation.compact.jwp.wrapped",
     lineWrap(presentedCompactOutput));

--- a/fixtures/su-es256-fixtures.mjs
+++ b/fixtures/su-es256-fixtures.mjs
@@ -68,17 +68,6 @@ let compactSerialization = [
 await fs.writeFile("build/su-es256-issuer.compact.jwp", compactSerialization, {encoding: "UTF-8"});
 await fs.writeFile("build/su-es256-issuer.compact.jwp.wrapped", lineWrap(compactSerialization));
 
-// JSON Serialization
-let jsonSerialization = {
-    issuer: encode(issuerProtectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: sigs.map(encode)
-};
-
-let jsonSerializationStr = JSON.stringify(jsonSerialization, null, 2);
-await fs.writeFile("build/su-es256-issuer.json.jwp", jsonSerializationStr);
-await fs.writeFile("build/su-es256-issuer.json.jwp.wrapped", lineWrap(jsonSerializationStr, 8));
-
 holderProtectedHeaderJSON.nonce = presentationNonceStr;
 let holderProtectedHeader = Buffer.from(JSON.stringify(holderProtectedHeaderJSON), "UTF-8");
 await fs.writeFile("build/su-es256-presentation-protected-header.json", JSON.stringify(holderProtectedHeaderJSON, null, 2), {encoding: "UTF-8"});
@@ -104,15 +93,3 @@ compactSerialization = [
 ].join(".");
 await fs.writeFile("build/su-es256-presentation.compact.jwp", compactSerialization, {encoding: "UTF-8"});
 await fs.writeFile("build/su-es256-presentation.compact.jwp.wrapped", lineWrap(compactSerialization));
-
-// JSON Serialization
-jsonSerialization = {
-    presentation: encode(holderProtectedHeader),
-    issuer: encode(issuerProtectedHeader),
-    payloads: payloads.map(jsonPayloadEncode),
-    proof: sigs.map(encode)
-};
-
-jsonSerializationStr = JSON.stringify(jsonSerialization, null, 2);
-await fs.writeFile("build/su-es256-presentation.json.jwp", jsonSerializationStr);
-await fs.writeFile("build/su-es256-presentation.json.jwp.wrapped", lineWrap(jsonSerializationStr, 8));


### PR DESCRIPTION
Per discussion at IETF 122, this change removes JSON serialization

- [x] first pass at text changes
- [x] remove templates and fixtures to generate JSON serialized examples
- [x] proofread changed sections in documents
- [x] verify document change history