### PR TITLE
Consolidate references

### DIFF
--- a/common-biblio.md
+++ b/common-biblio.md
@@ -1,0 +1,96 @@
+<reference anchor="ECMAScript" target="http://www.ecma-international.org/ecma-262/5.1/ECMA-262.pdf">
+  <front>
+    <title>ECMAScript Language Specification, 5.1 Edition</title>
+    <author>
+      <organization>Ecma International</organization>
+    </author>
+    <date month="June" year="2011"/>
+  </front>
+  <seriesInfo name="ECMA" value="262"/>
+  <format target="http://www.ecma-international.org/ecma-262/5.1/" type="HTML"/>
+  <format target="http://www.ecma-international.org/ecma-262/5.1/ECMA-262.pdf" type="PDF"/>
+</reference>
+<reference anchor="VC-DATA-MODEL-2.0" target="https://www.w3.org/TR/vc-data-model-2.0">
+  <front>
+    <title>Verifiable Credentials Data Model 2.0</title>
+    <author fullname="Manu Sporny">
+      <organization>Digital Bazaar</organization>
+    </author>
+    <author fullname="Ted Thibodeau Jr">
+      <organization>OpenLink Software</organization>
+    </author>
+    <author fullname="Ivan Herman">
+      <organization>W3C</organization>
+    </author>
+    <author fullname="Michael B. Jones">
+      <organization>Invited Expert</organization>
+    </author>
+    <author fullname="Gabe Cohen">
+      <organization>Block</organization>
+    </author>
+    <date day="27" month="December" year="2023"/>
+  </front>
+</reference>
+<reference anchor="IANA.CoAP.Formats" target="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats">
+  <front>
+    <title>CoAP Content-Formats</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.COSE" target="https://www.iana.org/assignments/cose">
+  <front>
+    <title>CBOR Object Signing and Encryption</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.CWT" target="https://www.iana.org/assignments/cwt">
+  <front>
+    <title>CBOR Web Token</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.JOSE" target="https://www.iana.org/assignments/jose">
+  <front>
+    <title>JSON Object Signing and Encryption</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.JWT" target="https://www.iana.org/assignments/jwt">
+  <front>
+    <title>JSON Web Token</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.MediaTypes" target="https://www.iana.org/assignments/media-types">
+  <front>
+    <title>Media Types</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>
+<reference anchor="IANA.StructuredSuffix" target="https://www.iana.org/assignments/media-type-structured-suffix/">
+  <front>
+    <title>Structured Syntax Suffix</title>
+    <author>
+      <organization>IANA</organization>
+    </author>
+    <date/>
+  </front>
+</reference>

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -617,27 +617,8 @@ Algorithm Analysis Documents(s):
 
 {backmatter}
 
-<reference anchor="VC-DATA-MODEL-2.0" target="https://www.w3.org/TR/vc-data-model-2.0">
-  <front>
-    <title>Verifiable Credentials Data Model 2.0</title>
-    <author fullname="Manu Sporny">
-      <organization>Digital Bazaar</organization>
-    </author>
-    <author fullname="Ted Thibodeau Jr">
-      <organization>OpenLink Software</organization>
-    </author>
-    <author fullname="Ivan Herman">
-      <organization>W3C</organization>
-    </author>
-    <author fullname="Michael B. Jones">
-      <organization>Invited Expert</organization>
-    </author>
-    <author fullname="Gabe Cohen">
-      <organization>Block</organization>
-    </author>
-   <date day="27" month="December" year="2023"/>
-  </front>
-</reference>
+{{common-biblio.md}}
+{{series-draft-biblio.md}}
 
 # Example JWPs
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -402,65 +402,8 @@ The CoAP Content-Format for a CBOR Proof Token (CPT) is as follows.
 
 {backmatter}
 
-<reference anchor="IANA.JOSE" target="https://www.iana.org/assignments/jose">
-  <front>
-    <title>JSON Object Signing and Encryption</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.COSE" target="https://www.iana.org/assignments/cose">
-  <front>
-    <title>CBOR Object Signing and Encryption</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.JWT" target="https://www.iana.org/assignments/jwt">
-  <front>
-    <title>JSON Web Token</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.CWT" target="https://www.iana.org/assignments/cwt">
-  <front>
-    <title>CBOR Web Token</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.MediaTypes" target="https://www.iana.org/assignments/media-types">
-  <front>
-    <title>Media Types</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.CoAP.Formats" target="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats">
-  <front>
-    <title>CoAP Content-Formats</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+{{common-biblio.md}}
+{{series-draft-biblio.md}}
 
 # Acknowledgements
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -950,83 +950,8 @@ using the JWP Compact Serialization.
 
 {backmatter}
 
-<reference anchor="VC-DATA-MODEL-2.0" target="https://www.w3.org/TR/vc-data-model-2.0">
-  <front>
-    <title>Verifiable Credentials Data Model 2.0</title>
-    <author fullname="Manu Sporny">
-      <organization>Digital Bazaar</organization>
-    </author>
-    <author fullname="Ted Thibodeau Jr">
-      <organization>OpenLink Software</organization>
-    </author>
-    <author fullname="Ivan Herman">
-      <organization>W3C</organization>
-    </author>
-    <author fullname="Michael B. Jones">
-      <organization>Invited Expert</organization>
-    </author>
-    <author fullname="Gabe Cohen">
-      <organization>Block</organization>
-    </author>
-   <date day="27" month="December" year="2023"/>
-  </front>
-</reference>
-
-<reference anchor="ECMAScript" target="http://www.ecma-international.org/ecma-262/5.1/ECMA-262.pdf">
-  <front>
-    <title>ECMAScript Language Specification, 5.1 Edition</title>
-    <author>
-      <organization>Ecma International</organization>
-    </author>
-    <date month="June" year="2011"/>
-  </front>
-  <seriesInfo name="ECMA" value="262"/>
-  <format target="http://www.ecma-international.org/ecma-262/5.1/" type="HTML" />
-  <format target="http://www.ecma-international.org/ecma-262/5.1/ECMA-262.pdf" type="PDF" />
-</reference>
-
-<reference anchor="IANA.MediaTypes" target="http://www.iana.org/assignments/media-types">
-  <front>
-    <title>Media Types</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-  <format target="http://www.iana.org/assignments/media-types"
-	  type="HTML" />
-</reference>
-
-<reference anchor="IANA.StructuredSuffix" target="https://www.iana.org/assignments/media-type-structured-suffix/">
-  <front>
-    <title>Structured Syntax Suffix</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.JWT" target="https://www.iana.org/assignments/jwt">
-  <front>
-    <title>JSON Web Token</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
-<reference anchor="IANA.CoAP.Formats" target="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats">
-  <front>
-    <title>CoAP Content-Formats</title>
-    <author>
-      <organization>IANA</organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-
+{{common-biblio.md}}
+{{series-draft-biblio.md}}
 
 # Acknowledgements
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -396,7 +396,7 @@ string value.
 When used as a CBOR Protected Header, the value is a binary string.
 
 This definition is intentionally parallel to the `nonce` claim
-registered in the IANA "JSON Web Token Claims" registry (#IANA.JWT).
+registered in the IANA "JSON Web Token Claims" registry [@IANA.JWT].
 
 Use of this Header Parameter is OPTIONAL.
 
@@ -964,6 +964,10 @@ for his valuable contributions to this specification.
 # Document History
 
   [[ To be removed from the final specification ]]
+
+ -latest
+
+  * Correct informative reference to the IANA JWT registry.
 
  -08
 

--- a/series-draft-biblio.md
+++ b/series-draft-biblio.md
@@ -1,0 +1,60 @@
+<reference anchor="I-D.ietf-jose-json-web-proof" target="https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-web-proof">
+    <front>
+        <title>JSON Web Proof</title>
+        <author fullname="David Waite" initials="D." surname="Waite">
+            <organization>Ping Identity</organization>
+        </author>
+        <author fullname="Michael B. Jones" initials="M. B." surname="Jones">
+            <organization>Self-Issued Consulting</organization>
+        </author>
+        <author fullname="Jeremie Miller" initials="J." surname="Miller">
+            <organization>Ping Identity</organization>
+        </author>
+        <abstract>
+            <t>
+The JOSE set of standards established JSON-based container formats for Keys, Signatures, and Encryption. They also established IANA registries to enable the algorithms and representations used for them to be extended. Since those were created, newer cryptographic algorithms that support selective disclosure and unlinkability have matured and started seeing early market adoption. The COSE set of standards likewise does this for CBOR-based containers, focusing on the needs of environments which are better served using CBOR, such as constrained devices and networks. This document defines a new container format similar in purpose and design to JSON Web Signature (JWS) and COSE Signed Messages called a _JSON Web Proof (JWP)_. Unlike JWS, which integrity-protects only a single payload, JWP can integrity-protect multiple payloads in one message. It also specifies a new presentation form that supports selective disclosure of individual payloads, enables additional proof computation, and adds a protected header to prevent replay.
+</t>
+        </abstract>
+    </front>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-jose-json-web-proof-latest"/>
+</reference>
+<reference anchor="I-D.ietf-jose-json-proof-algorithms" target="https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-proof-algorithms">
+    <front>
+        <title>JSON Proof Algorithms</title>
+        <author fullname="Michael B. Jones" initials="M. B." surname="Jones">
+            <organization>Self-Issued Consulting</organization>
+        </author>
+        <author fullname="David Waite" initials="D." surname="Waite">
+            <organization>Ping Identity</organization>
+        </author>
+        <author fullname="Jeremie Miller" initials="J." surname="Miller">
+            <organization>Ping Identity</organization>
+        </author>
+        <abstract>
+            <t>
+The JSON Proof Algorithms (JPA) specification registers cryptographic algorithms and identifiers to be used with the JSON Web Proof, JSON Web Key (JWK), and COSE specifications. It defines IANA registries for these identifiers.
+</t>
+        </abstract>
+    </front>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-jose-json-proof-algorithms-latest"/>
+</reference>
+<reference anchor="I-D.ietf-jose-json-proof-token" target="https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-proof-token">
+    <front>
+        <title>JSON Proof Token and CBOR Proof Token</title>
+        <author fullname="Michael B. Jones" initials="M. B." surname="Jones">
+            <organization>Self-Issued Consulting</organization>
+        </author>
+        <author fullname="David Waite" initials="D." surname="Waite">
+            <organization>Ping Identity</organization>
+        </author>
+        <author fullname="Jeremie Miller" initials="J." surname="Miller">
+            <organization>Ping Identity</organization>
+        </author>
+        <abstract>
+            <t>
+JSON Proof Token (JPT) is a compact, URL-safe, privacy-preserving representation of claims to be transferred between three parties. The claims in a JPT are encoded as base64url-encoded JSON objects that are used as the payloads of a JSON Web Proof (JWP) structure, enabling them to be digitally signed and selectively disclosed. JPTs also support reusability and unlinkability when using Zero-Knowledge Proofs (ZKPs). A CBOR-based representation of JPTs is also defined, called a CBOR Proof Token (CPT). It has the same properties of JPTs, but uses the JSON Web Proof (JWP) CBOR Serialization, rather than the JSON-based JWP Compact Serialization.
+</t>
+        </abstract>
+    </front>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-jose-json-proof-token-latest"/>
+</reference>


### PR DESCRIPTION
Correct two issues with references:

1. References to non-IETF documents are now consolidated into a single `common-biblio.md` included in all files.
2. References within this document series are overridden to point to the non-versioned "latest" document, to prevent draft releases from referencing the prior document version.