### PR TITLE
Payload slot definition and CDDL cleanup

### DIFF
--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -782,7 +782,7 @@ The first MAC is generated using the key `issuer_header` and a value of the issu
 <{{./fixtures/build/mac-h256-issuer-protected-header-mac.txt}}
 Figure: Issuer MAC of protected header (Base64url-Encoded)
 
-The issuer generates an array of derived keys with one for each payload by using the shared secret as the key, and the index of the payload (as `payload_{n}` in UTF-8 encoded octets) as the input in a HMAC operation. This results in the following set of derived keys:
+The issuer generates an array of derived keys with one for each payload by using the shared secret as the key, and the index of the payload slot (as `payload_{n}` in UTF-8 encoded octets) as the input in a HMAC operation. This results in the following set of derived keys:
 
 <{{./fixtures/build/mac-h256-issuer-derived-payload-keys.json}}
 Figure: Derived payload keys (Base64url-Encoded)
@@ -815,7 +815,10 @@ The holder will take the issuer proof (including shared secret) and derive the s
 
 In this case, the holder has decided not to disclose the last three claims provided by the issuer (corresponding to `email`, `address`, and `age_over_21`)
 
-For the disclosed payloads, the holder will provide the corresponding derived key. For the non-disclosed payloads, the holder will provide the corresponding MAC value.
+For each payload slot, the holder will provide one of two values as part of the
+proof value. For a disclosed payload, the holder will provide the corresponding
+derived key. For a non-disclosed payload, the holder will provide the
+corresponding MAC value.
 
 The final presented proof value is an array of octet strings. The contents are presentation header signature, followed by the issuer signature, then the value disclosed by the holder for each payload. This results in the following proof:
 
@@ -840,6 +843,10 @@ The BBS examples were generated using the library at https://github.com/mattrglo
 # Document History
 
   [[ To be removed from the final specification ]]
+ -10
+
+  * Clarify MAC issuance and presentation using new "payload slot"
+    nomenclature.
 
  -09
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -85,7 +85,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Background
 
-JWP defines a container binding together a protected header, one or more payloads, and a cryptographic proof.  It does not define how claims are organized into payloads and what formats they are in.
+JWP defines a container binding together a protected header, one or more payload slots, and a cryptographic proof.  It does not define how claims are organized into payloads and what formats they are in.
 JPTs are intended to be as close to a JWT as possible,
 while also supporting the selective disclosure and unlinkability of JWPs.
 Likewise, CPTs are intended to be as close to a CWT as possible,
@@ -173,11 +173,12 @@ A JSON Proof Token or CBOR Proof Token assigns each playload a claim name.
 Payloads MUST each have a negotiated and understood claim name
 within the application context.
 The simplest solution to establish payload claim names
-is as an ordered array that aligns with the included payloads.
+is as an ordered array that aligns with the ordering of payload slots.
 This claims array can be conveniently included in the Claims header parameter.
 
 The `claims` Header Parameter is an array listing the Claim Names
-corresponding to the JWP payloads, in the same order as the payloads.
+corresponding to the JWP payload slots, in the same order as the
+payload slots.
 Each array value is a Claim Name, as defined in [@!RFC7519] or [@!RFC8392].
 Use of this Header Parameter is OPTIONAL.
 
@@ -185,6 +186,7 @@ All JPT payloads that are claim values
 MUST be the base64url encoding of the UTF-8 representation of a JSON value.
 That said, predicate proofs derived from payload values are not represented as claims;
 they are contained in the presentation proof using algorithm-specific representations.
+
 All CPT payloads that are claim values
 MUST be a CBOR value.
 Likewise, CPT predicate proofs derived from payload values are not represented as claims;
@@ -252,20 +254,6 @@ A disclosed payload of a CPT is represented as a CBOR value.
 
 The placeholder indicating that a payload was not disclosed is represented as
 described in [@!I-D.ietf-jose-json-web-proof, Section 6] (Serializations).
-
-## Proof Methods
-
-Proof methods can be returned instead of a disclosed payload.
-These are generated in an algorithm-specific manner from information in the JWP's proof value.
-
-A proof method may be custom based on the capabilities of the algorithm.
-
-* TBD: Describe common proof method types available:
-  * range
-  * membership
-  * time
-  * knowledge
-  * linking
 
 # Example JPT and CPT
 
@@ -450,6 +438,9 @@ for his valuable contributions to this specification.
  -10
 
   * Registered `+jpt` and `+cpt` structured syntax suffixes.
+  * Clarify mapping of the `claims` array to payload data using
+    "payload slot" nomenclature
+  * Move proof methods text to JWP.
 
  -09
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -492,17 +492,13 @@ For example, rather than releasing a data of birth, the algorithm may include pr
 
 A non-exaustive list of such proof methods along with examples includes:
 
-Ranges
-: Age acceptable currently, Geolocation near a specified location
+* Ranges: Age acceptable currently, Geolocation near a specified location
 
-Membership / Non-membership
-: Contains a particular role, Credential is not considered revoked.
+* (Non-)Membership: Contains a particular role, Credential is not considered revoked.
 
-Knowledge
-: Holder has proof of possession of a secret key or secret value
+* Proof of Knowledge: Holder has proof of possession of a secret key or secret value
 
-Derived Values
-: A verifier-specific pseuonymous value based on the credential
+* Derived Values: (Verifier-specific) stable pseuonymous values
 
 ### Presentation Proof
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -484,9 +484,25 @@ The presentation has one or more payload slots, each of which either contains th
 
 The disclosed payloads will always be in the same array positions to preserve any index-based references by the application between the issued and presented forms of the JWP.  How the sparse array is represented is specific to the serialization used.
 
-In addition to disclosing the contents of a payload, some algorithms MAY support disclosing other information not represented as a payload.
+### Algorithm Specific Proof Methods
+
+In addition to disclosing the contents of a payload, some algorithms MAY support disclosing other information not representable as a payload.
 
 For example, rather than releasing a data of birth, the algorithm may include proof information indicating that the subject is over a certain age at the time of the presentation. Such information is not disclosed as a payload, and instead would be included in the presentation proof.
+
+A non-exaustive list of such proof methods along with examples includes:
+
+Ranges
+: Age acceptable currently, Geolocation near a specified location
+
+Membership / Non-membership
+: Contains a particular role, Credential is not considered revoked.
+
+Knowledge
+: Holder has proof of possession of a secret key or secret value
+
+Derived Values
+: A verifier-specific pseuonymous value based on the credential
 
 ### Presentation Proof
 
@@ -958,6 +974,7 @@ for his valuable contributions to this specification.
     need at least one `bstr`
   * (CDDL) `header_map`, `label` and `value` definitions imported from
     RFC 9052
+  * Receive examples of additional types of algorithm-specific proofs from JPT
 
  -09
 


### PR DESCRIPTION
Cleanups clarifying that messages have one or more payload slots. This includes also a few
clarifications that came about while doing this editorial pass.

Fixes #167, Fixes #169

  * Replaced `application/jwp+cbor` with `application/cwp`.
  * Registered `+cwp` structured syntax suffix and simplified +jwp suffix.
  * Expanded descriptions of and rationale for the serializations.
  * Payload nomenclature was clarified by adding the concept of payload slots. The issued form and presented form have a certain number of ordered payload slots, and a presentation may choose to omit information from a slot.
  * Recommendation for Isuser Protected Header is to make the header static aross issued JWP if possible, to prevent unintentional correlation by verifiers
  * Cleaned up the text around algorithmic support for additional proofs of knowledge outside of payload disclosure (e.g. range proofs)
  * Clarify that a proof is made up of multiple octet strings
  * (CDDL) The protected header definitions now reference `empty_or_serialized_map` properly
  * (CDDL) `payloads` is now `PayloadSlots`, and represents you need at least one slot
  * (CDDL) The issuer `PayloadSlots` contains `payload`, which is not omittable
  * (CDDL) The presented form likewise references `disclosable_payload`, which is nillable to represent omission
  * (CDDL) `Proof` is capitalized to match, and properly represents you need at least one `bstr`
  * (CDDL) `header_map`, `label` and `value` definitions imported from RFC 9052